### PR TITLE
Add licensing guidance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # scheduling-service
+
 A scheduling API
+
+## Licensing
+
+See [docs/licensing.md](docs/licensing.md) for details about AGPL obligations, commercial licensing options, and deployment scenarios.

--- a/docs/commercial-license.md
+++ b/docs/commercial-license.md
@@ -1,0 +1,14 @@
+# Scheduling Service Commercial License Terms (Summary)
+
+The commercial license grants rights to use, modify, and distribute Scheduling Service without the copyleft obligations of the GNU Affero General Public License.
+
+## Key Provisions
+
+1. **License scope:** Provides a non-exclusive, non-transferable license to use Scheduling Service in proprietary offerings.
+2. **Source code handling:** Allows you to keep modifications confidential and omit AGPL-style source distribution, subject to the agreement’s terms.
+3. **Support and warranties:** Includes eligibility for professional support and optional warranty coverage as specified in your order form.
+4. **Restrictions:** Prohibits relicensing or sublicensing the software outside of the agreement, reverse engineering, or removing copyright notices.
+
+## Getting the Full Agreement
+
+This summary is not legally binding. The authoritative contract is delivered during the procurement process. Contact `sales@example.com` to review the complete Scheduling Service Commercial License Agreement tailored to your organization.

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -1,0 +1,44 @@
+# Licensing Overview
+
+Scheduling Service is offered under a dual-license model so you can choose the option that best fits how you deploy the software.
+
+## License Texts
+
+- [GNU Affero General Public License v3.0](../LICENSE)
+- [Scheduling Service Commercial License Terms](commercial-license.md)
+
+## Obligations Under the GNU AGPL v3
+
+Using the community edition under the GNU Affero General Public License v3.0 means:
+
+- **Source availability:** If you distribute the software or make it available over a network (including as a hosted service) with modifications, you must provide the complete corresponding source code of those modifications to your users.
+- **Copyleft scope:** Any derivative work that you distribute must also be licensed under the AGPL v3 so downstream users inherit the same freedoms.
+- **No warranty:** The software is provided “as-is” with no warranty, as described in the license text.
+
+## Commercial Licensing Options
+
+A commercial license allows you to use Scheduling Service without the copyleft obligations of the AGPL. Typical benefits include:
+
+- Keeping proprietary modifications private while distributing or hosting the service.
+- Receiving commercial support, additional warranties, and negotiated service levels.
+- Combining Scheduling Service with third-party proprietary components without triggering reciprocal obligations.
+
+Contact the licensing team at `sales@example.com` to request pricing or receive a tailored agreement.
+
+## Self-Hosting for Free Without Source Changes
+
+You may deploy and operate Scheduling Service internally without charge under the AGPL as long as you do **not** modify the source code. Running the unmodified software for yourself does not create any obligation to publish your internal configurations or workflows. If you later modify the source, review the AGPL requirements above to ensure you provide those changes to users who can access the modified service.
+
+## Typical Usage Scenarios
+
+| Scenario | What it looks like | AGPL obligations | When to consider commercial licensing |
+| --- | --- | --- | --- |
+| **Open-source deployment** | Running the unmodified community edition or contributing improvements back to the project. | You can self-host freely. If you distribute builds or host modified code, share those modifications under the AGPL. | Usually not required unless you want to keep changes proprietary. |
+| **Internal fork** | Customizing the code for internal teams or subsidiaries only. | If employees or subsidiaries access a modified hosted service, provide them with the corresponding source under the AGPL. | Needed when you prefer to keep the fork private or integrate with closed-source components. |
+| **SaaS offering** | Providing Scheduling Service as part of a hosted product to paying customers. | Customers must receive access to the modified source if you change it. Network use triggers the AGPL’s sharing requirements. | Recommended to avoid disclosing proprietary enhancements or mixing with non-AGPL-compatible code. |
+
+## Additional Guidance
+
+- Document your deployment architecture and keep track of any code changes to simplify compliance.
+- If you distribute client libraries or SDKs alongside the service, ensure their licenses are compatible with your chosen model.
+- Consult legal counsel for definitive advice before launching commercial offerings.


### PR DESCRIPTION
## Summary
- add licensing guide covering AGPL obligations, commercial options, and deployment scenarios
- cross-link README to the new documentation and reference license texts
- provide a commercial license summary document for linking from the guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d09b4dbf008332ae40a3c57277161b