### PR TITLE
Support basic insert functionality with SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,32 @@
-/_build
-/cover
-/deps
-/doc
-/.fetch
-erl_crash.dump
-*.ez
-*.beam
-/config/*.secret.exs
-.elixir_ls/
-.kiro/
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Code coverage profiles and other test artifacts
+*.out
+coverage.*
+*.coverprofile
+profile.cov
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+# Editor/IDE
+# .idea/
+# .vscode/

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gettimora/timora
+
+go 1.24.0

--- a/pkg/sqlkit/db.go
+++ b/pkg/sqlkit/db.go
@@ -3,23 +3,104 @@ package sqlkit
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 )
 
-type DB struct {
-	sql     *sql.DB
-	dialect Dialect
+var _ DB = (*SQLDatabase)(nil)
+
+type (
+	DB interface {
+		Dialect() Dialect
+		ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+		QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+		Close() error
+
+		Insert(t Table) InsertQuery
+	}
+
+	SQLDatabase struct {
+		sql     *sql.DB
+		dialect Dialect
+		config  SQLDatabaseConfig
+	}
+
+	SQLDatabaseConfig struct {
+		Log       Logger
+		LogConfig LogConfig
+	}
+
+	LogConfig struct {
+		Enabled     bool
+		IncludeArgs bool
+		LogDuration bool
+	}
+
+	SQLDatabaseOption func(*SQLDatabaseConfig)
+
+	Logger interface {
+		Info(msg string, kv ...any)
+	}
+)
+
+func New(raw *sql.DB, dialect Dialect, opts ...SQLDatabaseOption) DB {
+	return NewSQLDatabase(raw, dialect, opts...)
 }
 
-func NewDB(raw *sql.DB, dialect Dialect) *DB {
-	return &DB{sql: raw, dialect: dialect}
+func NewSQLDatabase(raw *sql.DB, dialect Dialect, opts ...SQLDatabaseOption) *SQLDatabase {
+	cfg := defaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	db := &SQLDatabase{
+		sql:     raw,
+		dialect: dialect,
+		config:  cfg,
+	}
+	return db
 }
 
-func (db *DB) Dialect() Dialect { return db.dialect }
-
-func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
-	return db.sql.ExecContext(ctx, query, args...)
+func WithLogger(logger Logger) SQLDatabaseOption {
+	return func(cfg *SQLDatabaseConfig) {
+		if logger == nil {
+			panic("sqlkit: WithLogger(nil) is not allowed; use slog.Default() or a valid Logger")
+		}
+		cfg.Log = logger
+	}
 }
 
-func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
-	return db.sql.QueryContext(ctx, query, args...)
+func WithLogConfig(logConfig LogConfig) SQLDatabaseOption {
+	return func(cfg *SQLDatabaseConfig) {
+		cfg.LogConfig = logConfig
+	}
+}
+
+func defaultConfig() SQLDatabaseConfig {
+	return SQLDatabaseConfig{
+		Log: slog.Default(),
+		LogConfig: LogConfig{
+			Enabled:     false,
+			IncludeArgs: false,
+			LogDuration: false,
+		},
+	}
+}
+
+func (db *SQLDatabase) Dialect() Dialect { return db.dialect }
+
+func (db *SQLDatabase) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	ctx = withOperationStart(ctx)
+	res, err := db.sql.ExecContext(ctx, query, args...)
+	db.logQuery(ctx, "Running DB Execution", query, args, err)
+	return res, err
+}
+
+func (db *SQLDatabase) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	ctx = withOperationStart(ctx)
+	rows, err := db.sql.QueryContext(ctx, query, args...)
+	db.logQuery(ctx, "Running DB Query", query, args, err)
+	return rows, err
+}
+
+func (db *SQLDatabase) Close() error {
+	return db.sql.Close()
 }

--- a/pkg/sqlkit/db.go
+++ b/pkg/sqlkit/db.go
@@ -1,0 +1,25 @@
+package sqlkit
+
+import (
+	"context"
+	"database/sql"
+)
+
+type DB struct {
+	sql     *sql.DB
+	dialect Dialect
+}
+
+func NewDB(raw *sql.DB, dialect Dialect) *DB {
+	return &DB{sql: raw, dialect: dialect}
+}
+
+func (db *DB) Dialect() Dialect { return db.dialect }
+
+func (db *DB) ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error) {
+	return db.sql.ExecContext(ctx, query, args...)
+}
+
+func (db *DB) QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error) {
+	return db.sql.QueryContext(ctx, query, args...)
+}

--- a/pkg/sqlkit/dialect.go
+++ b/pkg/sqlkit/dialect.go
@@ -1,0 +1,11 @@
+package sqlkit
+
+// Dialect defines SQL dialect-specific behaviors.
+type Dialect interface {
+	// Placeholder returns the placeholder string for the n-th parameter.
+	// For example, in Postgres, Placeholder(1) returns "$1".
+	Placeholder(n int) string
+	// QuoteIdent returns the quoted identifier for the given name.
+	// For example, in Postgres, QuoteIdent("user") returns `"user"`.
+	QuoteIdent(name string) string
+}

--- a/pkg/sqlkit/go.mod
+++ b/pkg/sqlkit/go.mod
@@ -1,0 +1,5 @@
+module github.com/gettimora/timora/pkg/sqlkit
+
+go 1.24.0
+
+require github.com/mattn/go-sqlite3 v1.14.32

--- a/pkg/sqlkit/go.sum
+++ b/pkg/sqlkit/go.sum
@@ -1,0 +1,2 @@
+github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
+github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/pkg/sqlkit/insert.go
+++ b/pkg/sqlkit/insert.go
@@ -1,0 +1,66 @@
+package sqlkit
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+type InsertQuery struct {
+	db      *DB
+	table   Table
+	columns []Column
+	rows    [][]any
+}
+
+func (db *DB) Insert(t Table) *InsertQuery {
+	return &InsertQuery{db: db, table: t}
+}
+
+func (q *InsertQuery) Columns(cols ...Column) *InsertQuery {
+	q.columns = cols
+	return q
+}
+
+func (q *InsertQuery) Values(vals ...any) *InsertQuery {
+	q.rows = append(q.rows, vals)
+	return q
+}
+
+func (q *InsertQuery) BuildSQL() (string, []any) {
+	d := q.db.Dialect()
+
+	colNames := make([]string, len(q.columns))
+	for i, c := range q.columns {
+		colNames[i] = d.QuoteIdent(c.Name())
+	}
+
+	args := make([]any, 0, len(q.rows)*len(q.columns))
+	placeholders := make([]string, 0, len(q.rows))
+	for _, row := range q.rows {
+		rowPlaceholders := make([]string, len(row))
+		for j := range row {
+			rowPlaceholders[j] = d.Placeholder(len(args) + j + 1)
+		}
+		args = append(args, row...)
+		placeholders = append(placeholders, fmt.Sprintf("(%s)", strings.Join(rowPlaceholders, ", ")))
+		args = append(args, row...)
+		args = args[:len(args)-len(row)]
+		args = append(args, row...)
+	}
+
+	sql := fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES %s",
+		d.QuoteIdent(q.table.Name()),
+		strings.Join(colNames, ", "),
+		strings.Join(placeholders, ", "),
+	)
+
+	return sql, args
+}
+
+func (q *InsertQuery) Exec(ctx context.Context) (sql.Result, error) {
+	sqlStr, args := q.BuildSQL()
+	return q.db.ExecContext(ctx, sqlStr, args...)
+}

--- a/pkg/sqlkit/insert_example_test.go
+++ b/pkg/sqlkit/insert_example_test.go
@@ -1,0 +1,71 @@
+package sqlkit_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/gettimora/timora/pkg/sqlkit"
+	sqlkittesting "github.com/gettimora/timora/pkg/sqlkit/testing"
+)
+
+func ExampleDB_Insert() {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	db := sqlkittesting.NewExampleTestDB(sqlkit.WithLogger(logger),
+		sqlkit.WithLogConfig(sqlkit.LogConfig{
+			Enabled:     true,
+			IncludeArgs: true,
+			LogDuration: false,
+		}),
+		sqlkit.WithLogger(
+			slog.New(slog.NewTextHandler(
+				os.Stdout,
+				&slog.HandlerOptions{
+
+					AddSource: false,
+					ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+						if a.Key == slog.TimeKey {
+							a.Value = slog.StringValue("2025-11-02T00:00:00Z")
+						}
+						return a
+					},
+				})),
+		),
+	)
+
+	res, err := db.Insert(sqlkittesting.Examples).
+		Columns(
+			sqlkittesting.Examples.ID,
+			sqlkittesting.Examples.Text,
+			sqlkittesting.Examples.Value,
+			sqlkittesting.Examples.Unique,
+			sqlkittesting.Examples.CreatedAt,
+			sqlkittesting.Examples.IsActive,
+		).
+		Values(
+			1,
+			"Example 1",
+			1.1,
+			"unique-1",
+			time.Date(2023, 10, 11, 0, 0, 0, 0, time.UTC).Unix(),
+			true,
+		).
+		Exec(ctx)
+
+	if err != nil {
+		panic("failed to insert row: " + err.Error())
+	}
+
+	fmt.Println(res.LastInsertId())
+	fmt.Println(res.RowsAffected())
+
+	// Output:
+	// time=2025-11-02T00:00:00Z level=INFO msg="Running DB Execution" query="CREATE TABLE \"examples\" (\n\t\"id\" INTEGER PRIMARY KEY,\n\t\"text\" TEXT NOT NULL,\n\t\"value\" REAL,\n\t\"unique\" TEXT NOT NULL UNIQUE,\n\t\"created_at\" INTEGER NOT NULL,\n\t\"is_active\" INTEGER NOT NULL\n);" args=[]
+	// time=2025-11-02T00:00:00Z level=INFO msg="Running DB Execution" query="INSERT INTO \"examples\" (\"id\", \"text\", \"value\", \"unique\", \"created_at\", \"is_active\") VALUES (?, ?, ?, ?, ?, ?)" args="[1 Example 1 1.1 unique-1 1696982400 true]"
+	// 1 <nil>
+	// 1 <nil>
+}

--- a/pkg/sqlkit/insert_test.go
+++ b/pkg/sqlkit/insert_test.go
@@ -1,83 +1,151 @@
 package sqlkit_test
 
 import (
-	"database/sql"
 	"strings"
 	"testing"
 	"time"
 
-	test "github.com/gettimora/timora/pkg/sqlkit/testing"
+	sqlkittesting "github.com/gettimora/timora/pkg/sqlkit/testing"
 )
 
-func Test_Insert(t *testing.T) {
-	tests := []struct {
-		Name   string
-		Setup  []test.Option
-		Assert func(*testing.T, sql.Result, error)
-	}{
-		{
-			Name:  "Insert without values",
-			Setup: nil,
-			Assert: func(t *testing.T, res sql.Result, err error) {
-				if err != nil {
-					t.Fatalf("expected no error, got %v", err)
-				}
-				rowsAffected, err := res.RowsAffected()
-				if err != nil {
-					t.Fatalf("failed to get rows affected: %v", err)
-				}
-				if rowsAffected != 1 {
-					t.Fatalf("expected 1 row affected, got %d", rowsAffected)
-				}
-			},
-		},
-		{
-			Name: "Insert with copy of unique value",
-			Setup: []test.Option{
-				test.WithExample(test.Example{
-					ID:        1,
-					Text:      "example1",
-					Unique:    "unique1",
-					Value:     42,
-					CreatedAt: time.Now(),
-				}),
-			},
-			Assert: func(t *testing.T, res sql.Result, err error) {
-				if err == nil {
-					t.Fatalf("expected error, got none")
-				}
-				if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
-					t.Fatalf("expected UNIQUE constraint failed error, got %v", err)
-				}
-			},
-		},
-	}
+func TestInsert(t *testing.T) {
+	t.Run("Insert single row", func(t *testing.T) {
+		DB := sqlkittesting.NewInMemoryTestDB(t)
 
-	for _, tt := range tests {
-		t.Run(tt.Name, func(t *testing.T) {
-			DB := test.NewInMemoryTest(t, tt.Setup...)
+		res, err := DB.
+			Insert(sqlkittesting.Examples).
+			Columns(
+				sqlkittesting.Examples.ID,
+				sqlkittesting.Examples.Text,
+				sqlkittesting.Examples.Value,
+				sqlkittesting.Examples.Unique,
+				sqlkittesting.Examples.CreatedAt,
+				sqlkittesting.Examples.IsActive,
+			).
+			Values(
+				1,
+				"Example 1",
+				1.1,
+				"unique-1",
+				time.Now().Unix(),
+				true,
+			).
+			Exec(t.Context())
 
-			res, err := DB.
-				Insert(test.Examples).
-				Columns(
-					test.Examples.ID,
-					test.Examples.Text,
-					test.Examples.Unique,
-					test.Examples.Value,
-					test.Examples.CreatedAt,
-					test.Examples.IsActive,
-				).
-				Values(
-					1,
-					"example1",
-					"unique1",
-					42.4,
-					time.Now(),
-					true,
-				).
-				Exec(t.Context())
+		if err != nil {
+			t.Fatalf("failed to insert row: %v", err)
+		}
 
-			tt.Assert(t, res, err)
-		})
-	}
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatalf("failed to get rows affected: %v", err)
+		}
+
+		if rowsAffected != 1 {
+			t.Fatalf("expected 1 row affected, got %d", rowsAffected)
+		}
+
+		example, err := DB.GetExample(t, 1)
+		if err != nil {
+			t.Fatalf("failed to get inserted example: %v", err)
+		}
+
+		if example.ID != 1 ||
+			example.Text != "Example 1" ||
+			example.Value != 1.1 ||
+			example.Unique != "unique-1" ||
+			!example.IsActive {
+			t.Fatalf("inserted example does not match expected values: %+v", example)
+		}
+	})
+
+	t.Run("Insert multiple rows", func(t *testing.T) {
+		DB := sqlkittesting.NewInMemoryTestDB(t)
+
+		res, err := DB.
+			Insert(sqlkittesting.Examples).
+			Columns(
+				sqlkittesting.Examples.ID,
+				sqlkittesting.Examples.Text,
+				sqlkittesting.Examples.Value,
+				sqlkittesting.Examples.Unique,
+				sqlkittesting.Examples.CreatedAt,
+				sqlkittesting.Examples.IsActive,
+			).
+			Values(
+				1,
+				"Example 1",
+				1.1,
+				"unique-1",
+				time.Now().Unix(),
+				true,
+			).
+			Values(
+				2,
+				"Example 2",
+				2.2,
+				"unique-2",
+				time.Now().Unix(),
+				false,
+			).
+			Exec(t.Context())
+
+		if err != nil {
+			t.Fatalf("failed to insert multiple rows: %v", err)
+		}
+
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			t.Fatalf("failed to get rows affected: %v", err)
+		}
+
+		if rowsAffected != 2 {
+			t.Fatalf("expected 2 rows affected, got %d", rowsAffected)
+		}
+	})
+
+	t.Run("Insert duplicate primary key fails", func(t *testing.T) {
+		DB := sqlkittesting.NewInMemoryTestDB(t, sqlkittesting.WithExampleData(
+			&sqlkittesting.Example{
+				ID:        1,
+				Text:      "Example 1",
+				Value:     1.1,
+				Unique:    "unique-1",
+				CreatedAt: time.Now(),
+				IsActive:  true,
+			},
+		))
+
+		res, err := DB.
+			Insert(sqlkittesting.Examples).
+			Columns(
+				sqlkittesting.Examples.ID,
+				sqlkittesting.Examples.Text,
+				sqlkittesting.Examples.Value,
+				sqlkittesting.Examples.Unique,
+				sqlkittesting.Examples.CreatedAt,
+				sqlkittesting.Examples.IsActive,
+			).
+			Values(
+				1,
+				"Example 1 Copy",
+				1.1,
+				"unique-1-copy",
+				time.Now().Unix(),
+				true,
+			).
+			Exec(t.Context())
+
+		if err == nil {
+			t.Fatalf("expected error when inserting duplicate primary key, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
+			t.Fatalf("expected UNIQUE constraint failed error, got: %v", err)
+		}
+
+		if res != nil {
+			t.Fatalf("expected nil result when insert fails, got %v", res)
+		}
+	})
 }

--- a/pkg/sqlkit/insert_test.go
+++ b/pkg/sqlkit/insert_test.go
@@ -1,0 +1,83 @@
+package sqlkit_test
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	test "github.com/gettimora/timora/pkg/sqlkit/testing"
+)
+
+func Test_Insert(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Setup  []test.Option
+		Assert func(*testing.T, sql.Result, error)
+	}{
+		{
+			Name:  "Insert without values",
+			Setup: nil,
+			Assert: func(t *testing.T, res sql.Result, err error) {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				rowsAffected, err := res.RowsAffected()
+				if err != nil {
+					t.Fatalf("failed to get rows affected: %v", err)
+				}
+				if rowsAffected != 1 {
+					t.Fatalf("expected 1 row affected, got %d", rowsAffected)
+				}
+			},
+		},
+		{
+			Name: "Insert with copy of unique value",
+			Setup: []test.Option{
+				test.WithExample(test.Example{
+					ID:        1,
+					Text:      "example1",
+					Unique:    "unique1",
+					Value:     42,
+					CreatedAt: time.Now(),
+				}),
+			},
+			Assert: func(t *testing.T, res sql.Result, err error) {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
+					t.Fatalf("expected UNIQUE constraint failed error, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			DB := test.NewInMemoryTest(t, tt.Setup...)
+
+			res, err := DB.
+				Insert(test.Examples).
+				Columns(
+					test.Examples.ID,
+					test.Examples.Text,
+					test.Examples.Unique,
+					test.Examples.Value,
+					test.Examples.CreatedAt,
+					test.Examples.IsActive,
+				).
+				Values(
+					1,
+					"example1",
+					"unique1",
+					42.4,
+					time.Now(),
+					true,
+				).
+				Exec(t.Context())
+
+			tt.Assert(t, res, err)
+		})
+	}
+}

--- a/pkg/sqlkit/log.go
+++ b/pkg/sqlkit/log.go
@@ -1,0 +1,45 @@
+package sqlkit
+
+import (
+	"context"
+	"time"
+)
+
+type contextKeyOperationStart struct{}
+
+func withOperationStart(ctx context.Context) context.Context {
+	if _, ok := getOperationStart(ctx); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, contextKeyOperationStart{}, time.Now())
+}
+
+func getOperationStart(ctx context.Context) (time.Time, bool) {
+	t, ok := ctx.Value(contextKeyOperationStart{}).(time.Time)
+	return t, ok
+}
+
+func (db *SQLDatabase) logQuery(ctx context.Context, op string, query string, args []any, err error) {
+	cfg := db.config.LogConfig
+	if !cfg.Enabled {
+		return
+	}
+
+	fields := []any{"query", query}
+
+	if cfg.IncludeArgs {
+		fields = append(fields, "args", args)
+	}
+
+	if cfg.LogDuration {
+		if opStart, ok := getOperationStart(ctx); ok {
+			fields = append(fields, "operation_duration", time.Since(opStart))
+		}
+	}
+
+	if err != nil {
+		fields = append(fields, "error", err)
+	}
+
+	db.config.Log.Info(op, fields...)
+}

--- a/pkg/sqlkit/sqlite/dialect.go
+++ b/pkg/sqlkit/sqlite/dialect.go
@@ -1,0 +1,23 @@
+package sqlite
+
+import (
+	"fmt"
+
+	"github.com/gettimora/timora/pkg/sqlkit"
+)
+
+var _ sqlkit.Dialect = (*Dialect)(nil)
+
+type Dialect struct{}
+
+func NewDialect() *Dialect {
+	return &Dialect{}
+}
+
+func (d *Dialect) Placeholder(n int) string {
+	return "?"
+}
+
+func (d *Dialect) QuoteIdent(ident string) string {
+	return fmt.Sprintf(`"%s"`, ident)
+}

--- a/pkg/sqlkit/testing/inmemory.go
+++ b/pkg/sqlkit/testing/inmemory.go
@@ -1,8 +1,11 @@
-package testing
+package sqlkittesting
 
 import (
+	"context"
 	"database/sql"
+	"errors"
 	"testing"
+	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -11,15 +14,47 @@ import (
 )
 
 type (
-	Option func(*testing.T, *sqlkit.DB)
+	InMemoryTestDB struct {
+		sqlkit.DB
+	}
+
+	Option func(*testing.T, sqlkit.DB)
 )
 
-func NewInMemoryTest(t *testing.T, opts ...Option) *sqlkit.DB {
+func NewExampleTestDB(opts ...sqlkit.SQLDatabaseOption) *InMemoryTestDB {
 	db, err := sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		panic("failed to open in-memory sqlite database: " + err.Error())
 	}
-	DB := sqlkit.NewDB(db, sqlite.NewDialect())
+	DB := sqlkit.New(db, sqlite.NewDialect(), opts...)
+	imt := &InMemoryTestDB{DB: DB}
+
+	_, err = DB.ExecContext(context.Background(), CreateSchema)
+	if err != nil {
+		panic("failed to create schema: " + err.Error())
+	}
+
+	return imt
+}
+
+func NewInMemoryTestDB(t *testing.T, opts ...Option) *InMemoryTestDB {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic("failed to open in-memory sqlite database: " + err.Error())
+	}
+	DB := sqlkit.New(db, sqlite.NewDialect(), sqlkit.WithLogConfig(
+		sqlkit.LogConfig{
+			Enabled:     true,
+			IncludeArgs: true,
+			LogDuration: true,
+		},
+	))
+	imt := &InMemoryTestDB{DB: DB}
+	t.Cleanup(func() {
+		imt.Close(t)
+	})
 
 	_, err = DB.ExecContext(t.Context(), CreateSchema)
 	if err != nil {
@@ -30,32 +65,88 @@ func NewInMemoryTest(t *testing.T, opts ...Option) *sqlkit.DB {
 		opt(t, DB)
 	}
 
-	return DB
+	return imt
 }
 
-func WithExample(example Example) Option {
-	return func(t *testing.T, DB *sqlkit.DB) {
-		_, err := DB.
-			Insert(Examples).
-			Columns(
-				Examples.ID,
-				Examples.Text,
-				Examples.Unique,
-				Examples.Value,
-				Examples.CreatedAt,
-				Examples.IsActive,
-			).
-			Values(
-				example.ID,
-				example.Text,
-				example.Unique,
-				example.Value,
-				example.CreatedAt,
-				example.IsActive,
-			).
-			Exec(t.Context())
-		if err != nil {
-			t.Fatal("failed to insert example: " + err.Error())
+func (it *InMemoryTestDB) GetExample(t *testing.T, id int) (*Example, error) {
+	rows, err := it.QueryContext(
+		context.Background(),
+		`SELECT "id", "text", "value", "unique", "created_at", "is_active" FROM "examples" WHERE "id" = ?`,
+		id,
+	)
+	if err != nil && !errors.Is(sql.ErrNoRows, err) {
+		return nil, err
+	}
+	if err != nil {
+		t.Fatalf("failed to query example: %v", err)
+	}
+	defer rows.Close()
+
+	var example Example
+	var createdAtInt int64
+	var isActiveInt int
+
+	if !rows.Next() {
+		return nil, sql.ErrNoRows
+	}
+	err = rows.Scan(
+		&example.ID,
+		&example.Text,
+		&example.Value,
+		&example.Unique,
+		&createdAtInt,
+		&isActiveInt,
+	)
+	if err != nil {
+		return &example, err
+	}
+
+	example.CreatedAt = time.Unix(createdAtInt, 0)
+	example.IsActive = isActiveInt != 0
+
+	return &example, nil
+}
+
+func (it *InMemoryTestDB) AssertExample(t *testing.T, id int, fn func(t *testing.T, example Example)) {
+	t.Helper()
+	example, err := it.GetExample(t, id)
+	if err != nil {
+		t.Fatalf("failed to get example with id %d: %v", id, err)
+	}
+	fn(t, *example)
+}
+
+func (it *InMemoryTestDB) Close(t *testing.T) {
+	t.Helper()
+
+	if err := it.DB.Close(); err != nil {
+		t.Fatalf("failed to close in-memory database: %v", err)
+	}
+}
+
+func WithExampleData(examples ...*Example) Option {
+	return func(t *testing.T, db sqlkit.DB) {
+		t.Helper()
+
+		insert := db.Insert(Examples).Columns(
+			Examples.ID,
+			Examples.Text,
+			Examples.Value,
+			Examples.Unique,
+			Examples.CreatedAt,
+			Examples.IsActive,
+		)
+
+		for _, ex := range examples {
+			insert.Values(
+				ex.ID,
+				ex.Text,
+				ex.Value,
+				ex.Unique,
+				ex.CreatedAt.Unix(),
+				ex.IsActive,
+			)
 		}
+		insert.Exec(t.Context())
 	}
 }

--- a/pkg/sqlkit/testing/inmemory.go
+++ b/pkg/sqlkit/testing/inmemory.go
@@ -1,0 +1,61 @@
+package testing
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/gettimora/timora/pkg/sqlkit"
+	"github.com/gettimora/timora/pkg/sqlkit/sqlite"
+)
+
+type (
+	Option func(*testing.T, *sqlkit.DB)
+)
+
+func NewInMemoryTest(t *testing.T, opts ...Option) *sqlkit.DB {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic("failed to open in-memory sqlite database: " + err.Error())
+	}
+	DB := sqlkit.NewDB(db, sqlite.NewDialect())
+
+	_, err = DB.ExecContext(t.Context(), CreateSchema)
+	if err != nil {
+		t.Fatal("failed to create schema: " + err.Error())
+	}
+
+	for _, opt := range opts {
+		opt(t, DB)
+	}
+
+	return DB
+}
+
+func WithExample(example Example) Option {
+	return func(t *testing.T, DB *sqlkit.DB) {
+		_, err := DB.
+			Insert(Examples).
+			Columns(
+				Examples.ID,
+				Examples.Text,
+				Examples.Unique,
+				Examples.Value,
+				Examples.CreatedAt,
+				Examples.IsActive,
+			).
+			Values(
+				example.ID,
+				example.Text,
+				example.Unique,
+				example.Value,
+				example.CreatedAt,
+				example.IsActive,
+			).
+			Exec(t.Context())
+		if err != nil {
+			t.Fatal("failed to insert example: " + err.Error())
+		}
+	}
+}

--- a/pkg/sqlkit/testing/schema.go
+++ b/pkg/sqlkit/testing/schema.go
@@ -1,0 +1,57 @@
+package testing
+
+import (
+	"time"
+
+	"github.com/gettimora/timora/pkg/sqlkit"
+)
+
+const (
+	CreateSchema = `CREATE TABLE "examples" (
+	"id" INTEGER PRIMARY KEY,
+	"text" TEXT NOT NULL,
+	"value" REAL,
+	"unique" TEXT NOT NULL UNIQUE,
+	"created_at" INTEGER NOT NULL,
+	"is_active" INTEGER NOT NULL
+);`
+)
+
+type (
+	ExampleTable struct {
+		ID        sqlkit.ColumnOf[int]
+		Text      sqlkit.ColumnOf[string]
+		Value     sqlkit.ColumnOf[float64]
+		Unique    sqlkit.ColumnOf[string]
+		CreatedAt sqlkit.ColumnOf[time.Time]
+		IsActive  sqlkit.ColumnOf[bool]
+	}
+
+	Example struct {
+		ID        int
+		Text      string
+		Value     float64
+		Unique    string
+		CreatedAt time.Time
+		IsActive  bool
+	}
+)
+
+var (
+	Examples = NewExampleTable()
+)
+
+func NewExampleTable() *ExampleTable {
+	t := &ExampleTable{}
+	t.ID = sqlkit.NewIntColumn("id", t)
+	t.Text = sqlkit.NewStringColumn("text", t)
+	t.Value = sqlkit.NewFloatColumn("value", t)
+	t.Unique = sqlkit.NewStringColumn("unique", t)
+	t.CreatedAt = sqlkit.NewTimeColumn("created_at", t)
+	t.IsActive = sqlkit.NewBoolColumn("is_active", t)
+	return t
+}
+
+func (e *ExampleTable) Name() string {
+	return "examples"
+}

--- a/pkg/sqlkit/testing/schema.go
+++ b/pkg/sqlkit/testing/schema.go
@@ -1,4 +1,4 @@
-package testing
+package sqlkittesting
 
 import (
 	"time"

--- a/pkg/sqlkit/types.go
+++ b/pkg/sqlkit/types.go
@@ -1,0 +1,44 @@
+package sqlkit
+
+import "time"
+
+type (
+	Table interface {
+		Name() string
+	}
+
+	Column interface {
+		Name() string
+		Table() Table
+	}
+
+	ColumnOf[T any] struct {
+		ColName string
+		Tab     Table
+	}
+)
+
+var _ Column = ColumnOf[any]{}
+
+func (c ColumnOf[T]) Name() string { return c.ColName }
+func (c ColumnOf[T]) Table() Table { return c.Tab }
+
+func NewStringColumn(name string, table Table) ColumnOf[string] {
+	return ColumnOf[string]{ColName: name, Tab: table}
+}
+
+func NewIntColumn(name string, table Table) ColumnOf[int] {
+	return ColumnOf[int]{ColName: name, Tab: table}
+}
+
+func NewTimeColumn(name string, table Table) ColumnOf[time.Time] {
+	return ColumnOf[time.Time]{ColName: name, Tab: table}
+}
+
+func NewFloatColumn(name string, table Table) ColumnOf[float64] {
+	return ColumnOf[float64]{ColName: name, Tab: table}
+}
+
+func NewBoolColumn(name string, table Table) ColumnOf[bool] {
+	return ColumnOf[bool]{ColName: name, Tab: table}
+}

--- a/pkg/sqlkit/types.go
+++ b/pkg/sqlkit/types.go
@@ -9,36 +9,33 @@ type (
 
 	Column interface {
 		Name() string
-		Table() Table
 	}
 
 	ColumnOf[T any] struct {
 		ColName string
-		Tab     Table
 	}
 )
 
 var _ Column = ColumnOf[any]{}
 
 func (c ColumnOf[T]) Name() string { return c.ColName }
-func (c ColumnOf[T]) Table() Table { return c.Tab }
 
 func NewStringColumn(name string, table Table) ColumnOf[string] {
-	return ColumnOf[string]{ColName: name, Tab: table}
+	return ColumnOf[string]{ColName: name}
 }
 
 func NewIntColumn(name string, table Table) ColumnOf[int] {
-	return ColumnOf[int]{ColName: name, Tab: table}
+	return ColumnOf[int]{ColName: name}
 }
 
 func NewTimeColumn(name string, table Table) ColumnOf[time.Time] {
-	return ColumnOf[time.Time]{ColName: name, Tab: table}
+	return ColumnOf[time.Time]{ColName: name}
 }
 
 func NewFloatColumn(name string, table Table) ColumnOf[float64] {
-	return ColumnOf[float64]{ColName: name, Tab: table}
+	return ColumnOf[float64]{ColName: name}
 }
 
 func NewBoolColumn(name string, table Table) ColumnOf[bool] {
-	return ColumnOf[bool]{ColName: name, Tab: table}
+	return ColumnOf[bool]{ColName: name}
 }


### PR DESCRIPTION
Implement basic insert capabilities in the SQL kit, enabling interaction with SQLite databases. This includes defining the necessary structures and methods for constructing and executing insert queries.